### PR TITLE
Fix app identity: correct package ID, app label, and bundle identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ The app originated from a real-life incident where a friend suffered severe burn
 
 ```bash
 # Clone the repo
-git clone https://github.com/mohammadqu22/GurdianAngel.git
-cd GurdianAngel
+git clone https://github.com/mohammadqu22/GuardianAngel.git
+cd GuardianAngel
 
 # Install dependencies
 flutter pub get
@@ -92,7 +92,6 @@ flutter run
 - **Mohammad Quttaineh** – Flutter & Backend  
 - **Amru Alyan** – UI/UX & Architecture  
 - **Academic Supervisor:** Mrs. Alida'at Adler
-
 
 
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.gurdian_angel"
+    namespace = "com.guardianangel.app"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.gurdian_angel"
+        applicationId = "com.guardianangel.app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     
     <application
-        android:label="gurdian_angel"
+        android:label="Guardian Angel"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/kotlin/com/guardianangel/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/guardianangel/app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.gurdian_angel
+package com.guardianangel.app
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -496,7 +496,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.gurdianAngel;
+				PRODUCT_BUNDLE_IDENTIFIER = com.guardianangel.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -513,7 +513,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.gurdianAngel.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.guardianangel.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -531,7 +531,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.gurdianAngel.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.guardianangel.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.gurdianAngel.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.guardianangel.app.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -682,7 +682,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.gurdianAngel;
+				PRODUCT_BUNDLE_IDENTIFIER = com.guardianangel.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -704,7 +704,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.gurdianAngel;
+				PRODUCT_BUNDLE_IDENTIFIER = com.guardianangel.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -193,7 +193,9 @@ class _HomeScreenState extends State<HomeScreen> {
                         crossAxisCount: 2,
                         crossAxisSpacing: 16,
                         mainAxisSpacing: 16,
-                        padding: const EdgeInsets.only(bottom: 80),
+                        padding: EdgeInsets.only(
+                          bottom: 64 + 16 + MediaQuery.of(context).padding.bottom,
+                        ),
                         children: filteredEmergencies
                             .map((e) => _buildEmergencyCard(
                                   context,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -193,6 +193,7 @@ class _HomeScreenState extends State<HomeScreen> {
                         crossAxisCount: 2,
                         crossAxisSpacing: 16,
                         mainAxisSpacing: 16,
+                        padding: const EdgeInsets.only(bottom: 80),
                         children: filteredEmergencies
                             .map((e) => _buildEmergencyCard(
                                   context,

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,10 +4,10 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "gurdian_angel")
+set(BINARY_NAME "guardian_angel")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.gurdian_angel")
+set(APPLICATION_ID "com.guardianangel.app")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -45,11 +45,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "gurdian_angel");
+    gtk_header_bar_set_title(header_bar, "guardian_angel");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "gurdian_angel");
+    gtk_window_set_title(window, "guardian_angel");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -45,11 +45,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "guardian_angel");
+    gtk_header_bar_set_title(header_bar, "Guardian Angel");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "guardian_angel");
+    gtk_window_set_title(window, "Guardian Angel");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(gurdian_angel LANGUAGES CXX)
+project(guardian_angel LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "gurdian_angel")
+set(BINARY_NAME "guardian_angel")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "gurdian_angel" "\0"
+            VALUE "FileDescription", "guardian_angel" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "gurdian_angel" "\0"
+            VALUE "InternalName", "guardian_angel" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2026 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "gurdian_angel.exe" "\0"
-            VALUE "ProductName", "gurdian_angel" "\0"
+            VALUE "OriginalFilename", "guardian_angel.exe" "\0"
+            VALUE "ProductName", "guardian_angel" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,13 +89,13 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "guardian_angel" "\0"
+            VALUE "CompanyName", "com.guardianangel.app" "\0"
+            VALUE "FileDescription", "Guardian Angel" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "guardian_angel" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2026 com.example. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2026 com.guardianangel.app. All rights reserved." "\0"
             VALUE "OriginalFilename", "guardian_angel.exe" "\0"
-            VALUE "ProductName", "guardian_angel" "\0"
+            VALUE "ProductName", "Guardian Angel" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"guardian_angel", origin, size)) {
+  if (!window.Create(L"Guardian Angel", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"gurdian_angel", origin, size)) {
+  if (!window.Create(L"guardian_angel", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## Summary

- **Android**: namespace and applicationId `com.example.gurdian_angel` → `com.guardianangel.app`; app label `gurdian_angel` → `Guardian Angel`; `MainActivity.kt` moved to the matching package path `com/guardianangel/app/`
- **iOS**: all bundle identifiers `com.example.gurdianAngel` → `com.guardianangel.app`
- **Linux / Windows**: binary name and application ID `gurdian_angel` → `guardian_angel`
- **README**: clone URL typo fixed (`GurdianAngel` → `GuardianAngel`)

## Test plan

- [ ] `flutter analyze` passes (no issues)
- [ ] Android build resolves `MainActivity` from the new package path
- [ ] iOS build uses the updated bundle identifier
- [ ] App label shows "Guardian Angel" on Android home screen

🤖 Generated with [Claude Code](https://claude.ai/claude-code)