### PR TITLE
Add location sharing to emergency protocol flows

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -48,5 +48,9 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- Fix #7: Android 11+ package visibility — required for launchUrl to
+             resolve the WhatsApp deep-link on API 30+ devices. -->
+        <package android:name="com.whatsapp" />
+        <package android:name="com.whatsapp.w4b" />
     </queries>
 </manifest>

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -490,13 +490,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = R59Y84423R;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.guardianangel.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amrualyan.guardianangel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -513,7 +514,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.guardianangel.app.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amrualyan.guardianangel.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -531,7 +532,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.guardianangel.app.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amrualyan.guardianangel.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +548,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.guardianangel.app.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amrualyan.guardianangel.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -676,13 +677,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = R59Y84423R;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.guardianangel.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amrualyan.guardianangel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -698,13 +700,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = R59Y84423R;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.guardianangel.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amrualyan.guardianangel;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -66,6 +66,12 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<!-- Fix #8: required for launchUrl to open sms: and whatsapp:// schemes on iOS. -->
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>sms</string>
+		<string>whatsapp</string>
+	</array>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Guardian Angel requires access to your location to share with emergency responders and find nearby medical services.</string>
 	<key>NSLocationAlwaysUsageDescription</key>

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -93,6 +93,16 @@
   "settingsLocationCoords": "الإحداثيات: {coords}",
   "settingsLocationCopy": "نسخ الرابط",
   "settingsLocationCopied": "تم نسخ رابط الموقع! 📋",
+  "locationShareTitle": "مشاركة موقعي",
+  "locationShareMessage": "أحتاج إلى مساعدة! موقعي الحالي: {link}",
+  "@locationShareMessage": {
+    "placeholders": {
+      "link": { "type": "String" }
+    }
+  },
+  "locationShareWhatsApp": "واتساب",
+  "locationShareSms": "رسالة نصية",
+  "locationShareNotAvailable": "التطبيق غير متاح على هذا الجهاز",
 
   "incidentLogTitle": "سجل الحوادث",
   "incidentLogEntry": "تم فتح بروتوكول {emergencyTitle}",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -117,6 +117,16 @@
   },
   "settingsLocationCopy": "Copy Link",
   "settingsLocationCopied": "Location link copied! 📋",
+  "locationShareTitle": "Share My Location",
+  "locationShareMessage": "I need help! My current location: {link}",
+  "@locationShareMessage": {
+    "placeholders": {
+      "link": { "type": "String" }
+    }
+  },
+  "locationShareWhatsApp": "WhatsApp",
+  "locationShareSms": "SMS",
+  "locationShareNotAvailable": "App not available on this device",
 
   "incidentLogTitle": "Incident Log",
   "incidentLogEntry": "Opened {emergencyTitle} protocol",

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -84,6 +84,16 @@
   "settingsLocationCoords": "קואורדינטות: {coords}",
   "settingsLocationCopy": "העתק קישור",
   "settingsLocationCopied": "קישור המיקום הועתק! 📋",
+  "locationShareTitle": "שתף את מיקומי",
+  "locationShareMessage": "אני צריך עזרה! המיקום שלי כרגע: {link}",
+  "@locationShareMessage": {
+    "placeholders": {
+      "link": { "type": "String" }
+    }
+  },
+  "locationShareWhatsApp": "WhatsApp",
+  "locationShareSms": "SMS",
+  "locationShareNotAvailable": "האפליקציה אינה זמינה במכשיר זה",
   "incidentLogTitle": "יומן אירועים",
   "incidentLogEntry": "נפתח פרוטוקול {emergencyTitle}",
   "incidentLogProgress": "הגעת ל-{completed} מתוך {total} שלבים",

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -91,8 +91,8 @@
       "link": { "type": "String" }
     }
   },
-  "locationShareWhatsApp": "WhatsApp",
-  "locationShareSms": "SMS",
+  "locationShareWhatsApp": "וואטסאפ",
+  "locationShareSms": "מסרון",
   "locationShareNotAvailable": "האפליקציה אינה זמינה במכשיר זה",
   "incidentLogTitle": "יומן אירועים",
   "incidentLogEntry": "נפתח פרוטוקול {emergencyTitle}",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -604,6 +604,36 @@ abstract class AppLocalizations {
   /// **'Location link copied! 📋'**
   String get settingsLocationCopied;
 
+  /// No description provided for @locationShareTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Share My Location'**
+  String get locationShareTitle;
+
+  /// No description provided for @locationShareMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'I need help! My current location: {link}'**
+  String locationShareMessage(String link);
+
+  /// No description provided for @locationShareWhatsApp.
+  ///
+  /// In en, this message translates to:
+  /// **'WhatsApp'**
+  String get locationShareWhatsApp;
+
+  /// No description provided for @locationShareSms.
+  ///
+  /// In en, this message translates to:
+  /// **'SMS'**
+  String get locationShareSms;
+
+  /// No description provided for @locationShareNotAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'App not available on this device'**
+  String get locationShareNotAvailable;
+
   /// No description provided for @incidentLogTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -279,6 +279,23 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settingsLocationCopied => 'تم نسخ رابط الموقع! 📋';
 
   @override
+  String get locationShareTitle => 'مشاركة موقعي';
+
+  @override
+  String locationShareMessage(String link) {
+    return 'أحتاج إلى مساعدة! موقعي الحالي: $link';
+  }
+
+  @override
+  String get locationShareWhatsApp => 'واتساب';
+
+  @override
+  String get locationShareSms => 'رسالة نصية';
+
+  @override
+  String get locationShareNotAvailable => 'التطبيق غير متاح على هذا الجهاز';
+
+  @override
   String get incidentLogTitle => 'سجل الحوادث';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -281,6 +281,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsLocationCopied => 'Location link copied! 📋';
 
   @override
+  String get locationShareTitle => 'Share My Location';
+
+  @override
+  String locationShareMessage(String link) {
+    return 'I need help! My current location: $link';
+  }
+
+  @override
+  String get locationShareWhatsApp => 'WhatsApp';
+
+  @override
+  String get locationShareSms => 'SMS';
+
+  @override
+  String get locationShareNotAvailable => 'App not available on this device';
+
+  @override
   String get incidentLogTitle => 'Incident Log';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -279,6 +279,23 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settingsLocationCopied => 'קישור המיקום הועתק! 📋';
 
   @override
+  String get locationShareTitle => 'שתף את מיקומי';
+
+  @override
+  String locationShareMessage(String link) {
+    return 'אני צריך עזרה! המיקום שלי כרגע: $link';
+  }
+
+  @override
+  String get locationShareWhatsApp => 'WhatsApp';
+
+  @override
+  String get locationShareSms => 'SMS';
+
+  @override
+  String get locationShareNotAvailable => 'האפליקציה אינה זמינה במכשיר זה';
+
+  @override
   String get incidentLogTitle => 'יומן אירועים';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -287,10 +287,10 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
-  String get locationShareWhatsApp => 'WhatsApp';
+  String get locationShareWhatsApp => 'וואטסאפ';
 
   @override
-  String get locationShareSms => 'SMS';
+  String get locationShareSms => 'מסרון';
 
   @override
   String get locationShareNotAvailable => 'האפליקציה אינה זמינה במכשיר זה';

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:guardian_angel/l10n/app_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../services/database_service.dart';
-import '../services/location_service.dart';
 import '../services/phone_service.dart';
 import '../core/app_theme.dart';
 import '../widgets/gradient_button.dart';
+import '../widgets/share_location_sheet.dart';
 import '../widgets/source_item.dart';
 import 'incident_log_screen.dart';
 
@@ -223,136 +222,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
     await PhoneService.call(phone, context, l10n.settingsCallFailed);
   }
 
-  Future<void> _showLocationDialog() async {
-    final l10n = AppLocalizations.of(context)!;
-
-    showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (context) {
-        final dialogCs = Theme.of(context).colorScheme;
-        return Dialog(
-          backgroundColor: dialogCs.surfaceContainerLowest,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(AppRadius.xl)),
-          child: Padding(
-            padding: const EdgeInsets.all(24),
-            child: Row(
-              children: [
-                CircularProgressIndicator(color: dialogCs.primary),
-                const SizedBox(width: 16),
-                Text(l10n.settingsLocationFetching),
-              ],
-            ),
-          ),
-        );
-      },
-    );
-
-    final position = await LocationService.getCurrentLocation();
-    if (mounted) Navigator.pop(context);
-
-    if (position == null) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.settingsLocationFailed)),
-        );
-      }
-      return;
-    }
-
-    final mapsLink  = LocationService.getMapsLink(position);
-    final formatted = LocationService.formatLocation(position);
-
-    if (mounted) {
-      showDialog(
-        context: context,
-        builder: (context) {
-          final dialogCs = Theme.of(context).colorScheme;
-          final theme    = Theme.of(context);
-          final dl10n    = AppLocalizations.of(context)!;
-          return Dialog(
-            backgroundColor: dialogCs.surfaceContainerLowest,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(AppRadius.xl)),
-            child: Padding(
-              padding: const EdgeInsets.all(24),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Row(
-                    children: [
-                      Icon(Icons.location_on, color: dialogCs.primary),
-                      const SizedBox(width: 10),
-                      Text(
-                        dl10n.settingsLocationDialogTitle,
-                        style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 16),
-                  Text(
-                    dl10n.settingsLocationShareHint,
-                    style: theme.textTheme.bodyMedium?.copyWith(color: dialogCs.onSurfaceVariant),
-                  ),
-                  const SizedBox(height: 12),
-                  Container(
-                    padding: const EdgeInsets.all(14),
-                    decoration: BoxDecoration(
-                      color: dialogCs.surfaceContainerLow,
-                      borderRadius: BorderRadius.circular(AppRadius.md),
-                    ),
-                    child: Text(mapsLink, style: theme.textTheme.bodyMedium),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    dl10n.settingsLocationCoords(formatted),
-                    style: theme.textTheme.labelSmall?.copyWith(color: dialogCs.outline),
-                  ),
-                  const SizedBox(height: 20),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      TextButton(
-                        onPressed: () => Navigator.pop(context),
-                        child: Text(dl10n.settingsClose),
-                      ),
-                      const SizedBox(width: 8),
-                      GradientButton(
-                        gradientColors: [dialogCs.primary, dialogCs.primaryContainer],
-                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                        onTap: () {
-                          final messenger = ScaffoldMessenger.of(context);
-                          Clipboard.setData(ClipboardData(text: mapsLink));
-                          Navigator.pop(context);
-                          messenger.showSnackBar(
-                            SnackBar(content: Text(dl10n.settingsLocationCopied)),
-                          );
-                        },
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(Icons.copy, size: 18, color: dialogCs.onPrimary),
-                            const SizedBox(width: 8),
-                            Text(
-                              dl10n.settingsLocationCopy,
-                              style: theme.textTheme.labelLarge?.copyWith(
-                                color: dialogCs.onPrimary,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-          );
-        },
-      );
-    }
-  }
+  Future<void> _showLocationDialog() =>
+      ShareLocationSheet.show(context);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/step_screen.dart
+++ b/lib/screens/step_screen.dart
@@ -47,6 +47,7 @@ class _StepScreenState extends State<StepScreen> {
   DateTime? _sessionEndedAt;
   DateTime? _stepStartedAt;
   List<int> _stepDurations = [];
+  bool _locationSharing = false; // guard against double-tap on location button
 
   void _checkScrollable() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -343,10 +344,21 @@ class _StepScreenState extends State<StepScreen> {
           IconButton(
             icon: const Icon(Icons.location_on_outlined),
             tooltip: l10n.settingsShareLocation,
-            onPressed: () => ShareLocationSheet.show(
-              context,
-              accentColor: widget.emergencyColor,
-            ),
+            // Fix #9: null disables the button while a share is in progress,
+            // preventing double-tap from opening two GPS dialogs.
+            onPressed: _locationSharing
+                ? null
+                : () async {
+                    setState(() => _locationSharing = true);
+                    try {
+                      await ShareLocationSheet.show(
+                        context,
+                        accentColor: widget.emergencyColor,
+                      );
+                    } finally {
+                      if (mounted) setState(() => _locationSharing = false);
+                    }
+                  },
           ),
         ],
       ),

--- a/lib/screens/step_screen.dart
+++ b/lib/screens/step_screen.dart
@@ -8,6 +8,7 @@ import '../core/app_theme.dart';
 import '../core/duration_formatting.dart';
 import '../core/number_formatting.dart';
 import '../widgets/gradient_button.dart';
+import '../widgets/share_location_sheet.dart';
 import '../services/database_service.dart';
 import '../services/tts_service.dart';
 
@@ -338,6 +339,16 @@ class _StepScreenState extends State<StepScreen> {
         foregroundColor: cs.onSurface,
         elevation: 0,
         centerTitle: false,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.location_on_outlined),
+            tooltip: l10n.settingsShareLocation,
+            onPressed: () => ShareLocationSheet.show(
+              context,
+              accentColor: widget.emergencyColor,
+            ),
+          ),
+        ],
       ),
       body: _loading
           ? Center(

--- a/lib/services/location_service.dart
+++ b/lib/services/location_service.dart
@@ -17,6 +17,7 @@ class LocationService {
     return await Geolocator.getCurrentPosition(
       locationSettings: const LocationSettings(
         accuracy: LocationAccuracy.high,
+        timeLimit: Duration(seconds: 15),
       ),
     );
   }

--- a/lib/widgets/share_location_sheet.dart
+++ b/lib/widgets/share_location_sheet.dart
@@ -1,0 +1,279 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../core/app_theme.dart';
+import '../l10n/app_localizations.dart';
+import '../services/location_service.dart';
+
+class ShareLocationSheet {
+  /// Fetches the current location, then shows a bottom sheet with three
+  /// share options: WhatsApp, SMS, and Copy to clipboard.
+  static Future<void> show(
+    BuildContext context, {
+    Color? accentColor,
+  }) async {
+    final l10n = AppLocalizations.of(context)!;
+
+    // Show a loading dialog while GPS resolves.
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) {
+        final cs = Theme.of(ctx).colorScheme;
+        return Dialog(
+          backgroundColor: cs.surfaceContainerLowest,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadius.xl),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                CircularProgressIndicator(color: cs.primary),
+                const SizedBox(width: 16),
+                Text(l10n.settingsLocationFetching),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+
+    final position = await LocationService.getCurrentLocation();
+    if (context.mounted) Navigator.pop(context);
+
+    if (position == null) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.settingsLocationFailed)),
+        );
+      }
+      return;
+    }
+
+    final mapsLink = LocationService.getMapsLink(position);
+    final coords = LocationService.formatLocation(position);
+    final message = l10n.locationShareMessage(mapsLink);
+
+    if (!context.mounted) return;
+
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Theme.of(context).colorScheme.surfaceContainerLowest,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadius.xl)),
+      ),
+      builder: (ctx) => _ShareSheet(
+        mapsLink: mapsLink,
+        coords: coords,
+        message: message,
+        accentColor: accentColor,
+      ),
+    );
+  }
+}
+
+class _ShareSheet extends StatelessWidget {
+  final String mapsLink;
+  final String coords;
+  final String message;
+  final Color? accentColor;
+
+  const _ShareSheet({
+    required this.mapsLink,
+    required this.coords,
+    required this.message,
+    this.accentColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final color = accentColor ?? cs.primary;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Handle bar
+            Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: cs.outlineVariant,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+
+            // Title row
+            Row(
+              children: [
+                Icon(Icons.location_on, color: color, size: 22),
+                const SizedBox(width: 10),
+                Text(
+                  l10n.locationShareTitle,
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+
+            // Maps link preview
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: cs.surfaceContainerLow,
+                borderRadius: BorderRadius.circular(AppRadius.md),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    mapsLink,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: cs.primary,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    l10n.settingsLocationCoords(coords),
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: cs.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 20),
+
+            // Share buttons
+            _ShareButton(
+              icon: Icons.chat,
+              label: l10n.locationShareWhatsApp,
+              color: const Color(0xFF25D366),
+              onTap: () => _shareWhatsApp(context, message, l10n),
+            ),
+            const SizedBox(height: 12),
+            _ShareButton(
+              icon: Icons.sms,
+              label: l10n.locationShareSms,
+              color: color,
+              onTap: () => _shareSms(context, message, l10n),
+            ),
+            const SizedBox(height: 12),
+            _ShareButton(
+              icon: Icons.copy,
+              label: l10n.settingsLocationCopy,
+              color: cs.secondary,
+              onTap: () => _copyToClipboard(context, mapsLink, l10n),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _shareWhatsApp(
+    BuildContext context,
+    String message,
+    AppLocalizations l10n,
+  ) async {
+    Navigator.pop(context);
+    final encoded = Uri.encodeComponent(message);
+    final uri = Uri.parse('https://wa.me/?text=$encoded');
+    if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.locationShareNotAvailable)),
+        );
+      }
+    }
+  }
+
+  Future<void> _shareSms(
+    BuildContext context,
+    String message,
+    AppLocalizations l10n,
+  ) async {
+    Navigator.pop(context);
+    final encoded = Uri.encodeComponent(message);
+    // iOS uses '&body=', Android uses '?body=' — the platform disambiguates
+    final uri = Uri.parse('sms:?body=$encoded');
+    if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.locationShareNotAvailable)),
+        );
+      }
+    }
+  }
+
+  void _copyToClipboard(
+    BuildContext context,
+    String link,
+    AppLocalizations l10n,
+  ) {
+    Clipboard.setData(ClipboardData(text: link));
+    Navigator.pop(context);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(l10n.settingsLocationCopied)),
+    );
+  }
+}
+
+class _ShareButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Color color;
+  final VoidCallback onTap;
+
+  const _ShareButton({
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        onPressed: onTap,
+        icon: Icon(icon, color: color, size: 20),
+        label: Text(
+          label,
+          style: theme.textTheme.titleMedium?.copyWith(
+            color: cs.onSurface,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        style: OutlinedButton.styleFrom(
+          alignment: Alignment.centerLeft,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          side: BorderSide(color: cs.outlineVariant),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadius.md),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/share_location_sheet.dart
+++ b/lib/widgets/share_location_sheet.dart
@@ -41,7 +41,15 @@ class ShareLocationSheet {
       },
     );
 
-    final position = await LocationService.getCurrentLocation();
+    // Fix #1 + #2: catch any exception from getCurrentLocation() (PlatformException,
+    // TimeoutException, etc.) and always dismiss the dialog via the outer mounted check.
+    final position = await () async {
+      try {
+        return await LocationService.getCurrentLocation();
+      } catch (_) {
+        return null;
+      }
+    }();
     if (context.mounted) Navigator.pop(context);
 
     if (position == null) {
@@ -58,7 +66,9 @@ class ShareLocationSheet {
 
     if (!context.mounted) return;
 
-    showModalBottomSheet<void>(
+    // Await the sheet so show() completes when the sheet is dismissed —
+    // this lets callers track whether sharing is in progress (e.g. re-entrancy guard).
+    await showModalBottomSheet<void>(
       context: context,
       backgroundColor: Theme.of(context).colorScheme.surfaceContainerLowest,
       shape: const RoundedRectangleBorder(
@@ -165,15 +175,17 @@ class _ShareSheet extends StatelessWidget {
     String message,
     AppLocalizations l10n,
   ) async {
+    // Fix #4 + #6: capture messenger BEFORE pop, and use whatsapp:// deep-link
+    // so launchUrl correctly returns false when WhatsApp is not installed
+    // (the https://wa.me/ fallback always returns true on iOS, silently opening Safari).
+    final messenger = ScaffoldMessenger.of(context);
     Navigator.pop(context);
     final encoded = Uri.encodeComponent(message);
-    final uri = Uri.parse('https://wa.me/?text=$encoded');
+    final uri = Uri.parse('whatsapp://send?text=$encoded');
     if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.locationShareNotAvailable)),
-        );
-      }
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.locationShareNotAvailable)),
+      );
     }
   }
 
@@ -182,15 +194,16 @@ class _ShareSheet extends StatelessWidget {
     String message,
     AppLocalizations l10n,
   ) async {
+    // Fix #6: capture messenger BEFORE pop so the snackbar is reachable
+    // even after the bottom sheet is dismissed.
+    final messenger = ScaffoldMessenger.of(context);
     Navigator.pop(context);
     final encoded = Uri.encodeComponent(message);
     final uri = Uri.parse('sms:?body=$encoded');
     if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.locationShareNotAvailable)),
-        );
-      }
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.locationShareNotAvailable)),
+      );
     }
   }
 
@@ -199,9 +212,13 @@ class _ShareSheet extends StatelessWidget {
     String link,
     AppLocalizations l10n,
   ) {
+    // Fix #5: capture messenger BEFORE pop; the bottom-sheet context is
+    // deactivated immediately after Navigator.pop, so ScaffoldMessenger.of(context)
+    // must not be called afterwards.
+    final messenger = ScaffoldMessenger.of(context);
     Clipboard.setData(ClipboardData(text: link));
     Navigator.pop(context);
-    ScaffoldMessenger.of(context).showSnackBar(
+    messenger.showSnackBar(
       SnackBar(content: Text(l10n.settingsLocationCopied)),
     );
   }

--- a/lib/widgets/share_location_sheet.dart
+++ b/lib/widgets/share_location_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../core/app_theme.dart';
 import '../l10n/app_localizations.dart';
@@ -99,9 +100,11 @@ class _ShareSheet extends StatelessWidget {
         padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
         child: Column(
           mainAxisSize: MainAxisSize.min,
+          // CrossAxisAlignment.start is direction-aware:
+          // aligns left in LTR, right in RTL.
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Handle bar
+            // Handle bar — always centered
             Center(
               child: Container(
                 width: 40,
@@ -114,7 +117,7 @@ class _ShareSheet extends StatelessWidget {
             ),
             const SizedBox(height: 20),
 
-            // Title row
+            // Title row — Row respects ambient Directionality
             Row(
               children: [
                 Icon(Icons.location_on, color: color, size: 22),
@@ -160,25 +163,30 @@ class _ShareSheet extends StatelessWidget {
             ),
             const SizedBox(height: 20),
 
-            // Share buttons
+            // WhatsApp
             _ShareButton(
-              icon: Icons.chat,
+              icon: FaIcon(
+                FontAwesomeIcons.whatsapp,
+                color: const Color(0xFF25D366),
+                size: 20,
+              ),
               label: l10n.locationShareWhatsApp,
-              color: const Color(0xFF25D366),
               onTap: () => _shareWhatsApp(context, message, l10n),
             ),
             const SizedBox(height: 12),
+
+            // SMS
             _ShareButton(
-              icon: Icons.sms,
+              icon: Icon(Icons.sms, color: color, size: 20),
               label: l10n.locationShareSms,
-              color: color,
               onTap: () => _shareSms(context, message, l10n),
             ),
             const SizedBox(height: 12),
+
+            // Copy
             _ShareButton(
-              icon: Icons.copy,
+              icon: Icon(Icons.copy, color: cs.secondary, size: 20),
               label: l10n.settingsLocationCopy,
-              color: cs.secondary,
               onTap: () => _copyToClipboard(context, mapsLink, l10n),
             ),
           ],
@@ -211,7 +219,6 @@ class _ShareSheet extends StatelessWidget {
   ) async {
     Navigator.pop(context);
     final encoded = Uri.encodeComponent(message);
-    // iOS uses '&body=', Android uses '?body=' — the platform disambiguates
     final uri = Uri.parse('sms:?body=$encoded');
     if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
       if (context.mounted) {
@@ -236,15 +243,13 @@ class _ShareSheet extends StatelessWidget {
 }
 
 class _ShareButton extends StatelessWidget {
-  final IconData icon;
+  final Widget icon;
   final String label;
-  final Color color;
   final VoidCallback onTap;
 
   const _ShareButton({
     required this.icon,
     required this.label,
-    required this.color,
     required this.onTap,
   });
 
@@ -257,7 +262,7 @@ class _ShareButton extends StatelessWidget {
       width: double.infinity,
       child: OutlinedButton.icon(
         onPressed: onTap,
-        icon: Icon(icon, color: color, size: 20),
+        icon: icon,
         label: Text(
           label,
           style: theme.textTheme.titleMedium?.copyWith(
@@ -266,7 +271,8 @@ class _ShareButton extends StatelessWidget {
           ),
         ),
         style: OutlinedButton.styleFrom(
-          alignment: Alignment.centerLeft,
+          // AlignmentDirectional.centerStart = left in LTR, right in RTL
+          alignment: AlignmentDirectional.centerStart,
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
           side: BorderSide(color: cs.outlineVariant),
           shape: RoundedRectangleBorder(

--- a/lib/widgets/share_location_sheet.dart
+++ b/lib/widgets/share_location_sheet.dart
@@ -54,7 +54,6 @@ class ShareLocationSheet {
     }
 
     final mapsLink = LocationService.getMapsLink(position);
-    final coords = LocationService.formatLocation(position);
     final message = l10n.locationShareMessage(mapsLink);
 
     if (!context.mounted) return;
@@ -67,7 +66,6 @@ class ShareLocationSheet {
       ),
       builder: (ctx) => _ShareSheet(
         mapsLink: mapsLink,
-        coords: coords,
         message: message,
         accentColor: accentColor,
       ),
@@ -77,13 +75,11 @@ class ShareLocationSheet {
 
 class _ShareSheet extends StatelessWidget {
   final String mapsLink;
-  final String coords;
   final String message;
   final Color? accentColor;
 
   const _ShareSheet({
     required this.mapsLink,
-    required this.coords,
     required this.message,
     this.accentColor,
   });
@@ -129,37 +125,6 @@ class _ShareSheet extends StatelessWidget {
                   ),
                 ),
               ],
-            ),
-            const SizedBox(height: 8),
-
-            // Maps link preview
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: cs.surfaceContainerLow,
-                borderRadius: BorderRadius.circular(AppRadius.md),
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    mapsLink,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: cs.primary,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    l10n.settingsLocationCoords(coords),
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: cs.onSurfaceVariant,
-                    ),
-                  ),
-                ],
-              ),
             ),
             const SizedBox(height: 20),
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,6 +181,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  font_awesome_flutter:
+    dependency: "direct main"
+    description:
+      name: font_awesome_flutter
+      sha256: b9011df3a1fa02993630b8fb83526368cf2206a711259830325bab2f1d2a4eb0
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.12.0"
   geolocator:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,9 @@ dependencies:
   geolocator: ^13.0.2
   google_fonts: ^8.0.2
 
+  # Brand icons (WhatsApp, etc.)
+  font_awesome_flutter: ^10.7.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary

- **New `ShareLocationSheet` widget** — reusable bottom sheet that fetches the user's GPS location and offers three share options: WhatsApp, SMS, and copy-to-clipboard. Shown in both the emergency `StepScreen` (AppBar icon) and Settings.
- **RTL-aware layout** — `AlignmentDirectional.centerStart` and Flutter's ambient `Directionality` ensure correct alignment in Hebrew and Arabic.
- **Localized labels** — WhatsApp/SMS button labels translated for all three locales (en/he/ar); Hebrew uses וואטסאפ/מסרון, Arabic uses واتساب/رسالة نصية.
- **Real WhatsApp brand icon** via `font_awesome_flutter`.
- **iOS signing** — bundle ID updated to `com.amrualyan.guardianangel` and development team set so the app deploys to a physical device.

## What changed

| File | Change |
|---|---|
| `lib/widgets/share_location_sheet.dart` | New widget (WhatsApp, SMS, clipboard sharing) |
| `lib/screens/step_screen.dart` | AppBar location-share button with re-entrancy guard |
| `lib/screens/settings_screen.dart` | Delegates to `ShareLocationSheet.show()`, removes 130-line inline dialog |
| `lib/services/location_service.dart` | Added 15-second GPS timeout |
| `lib/l10n/app_{en,he,ar}.arb` + generated Dart | New `locationShare*` strings |
| `pubspec.yaml` | Added `font_awesome_flutter ^10.7.0` |
| `android/app/src/main/AndroidManifest.xml` | Added WhatsApp `<queries>` for Android 11+ visibility |
| `ios/Runner/Info.plist` | Added `LSApplicationQueriesSchemes` (sms, whatsapp) |
| `ios/Runner.xcodeproj/project.pbxproj` | Bundle ID + development team for physical device |

## Bug fixes included (from code review)

1. **Stuck loading dialog** — GPS exceptions now caught in try/catch so the `barrierDismissible:false` dialog is always dismissed.
2. **GPS timeout** — `LocationSettings(timeLimit: Duration(seconds: 15))` prevents indefinite hangs indoors.
3. **WhatsApp detection on iOS** — switched to `whatsapp://send?text=` deep-link; the old `https://wa.me/` URL always returned `true` on iOS (opening Safari silently).
4. **use-after-pop crash** — `ScaffoldMessenger` captured before `Navigator.pop` in all three share methods.
5. **Error snackbar unreachable** — same fix makes the "App not available" snackbar actually reachable after the sheet dismisses.
6. **Android WhatsApp visibility** — `<queries>` declaration required for API 30+ package resolution.
7. **iOS scheme queries** — `LSApplicationQueriesSchemes` required for `sms:` and `whatsapp://` schemes.
8. **Re-entrancy guard** — `_locationSharing` bool prevents double-tap from spawning two GPS dialogs.

## Test plan

- [ ] Tap location icon in StepScreen AppBar → loading spinner → bottom sheet appears
- [ ] Tap location icon in Settings → same sheet
- [ ] WhatsApp button opens WhatsApp with pre-filled message; shows snackbar if not installed
- [ ] SMS button opens compose with pre-filled body
- [ ] Copy button copies the Maps link and shows "copied" snackbar
- [ ] Hebrew/Arabic locale: sheet content and buttons are right-aligned, labels are translated
- [ ] Double-tap AppBar button quickly → only one dialog opens
- [ ] Build and run on physical iPhone (iOS 26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)