### PR TITLE
Fix: repeat-audio button silent when Free Mode is active

### DIFF
--- a/lib/screens/step_screen.dart
+++ b/lib/screens/step_screen.dart
@@ -891,11 +891,12 @@ Widget build(BuildContext context) {
                       ],
                     ),
                   ),
-                  // Repeat button — pinned at the bottom of the card, never scrolls away
+                  // Repeat button — pinned at the bottom of the card, never scrolls away.
+                  // Routes through _speakCurrentStep (not TtsService.repeat) so it
+                  // coordinates with Free Mode: mute the mic while re-reading, then
+                  // reopen it when the audio finishes — repeatably.
                   IconButton(
-                    onPressed: _ttsEnabled
-                        ? () => TtsService.instance.repeat()
-                        : null,
+                    onPressed: _ttsEnabled ? _speakCurrentStep : null,
                     icon: Icon(
                       Icons.replay_circle_filled,
                       color: _ttsEnabled


### PR DESCRIPTION
## Bug
Inside a protocol, with **Free Mode** active, pressing the **repeat/replay audio** button did nothing — the current step was not re-read.

## Root cause
The repeat button called `TtsService.repeat()` directly, bypassing Free Mode's mic coordination. While Free Mode is listening, `speech_to_text` holds the iOS audio session in *record* mode, so the repeat playback was suppressed (silent). An integration gap surfaced by combining the learning-mode repeat button with Free Mode (PR #23).

## Fix
Route the button through `_speakCurrentStep()` instead, which already:
1. mutes the mic (`_narrating`, `_stopHandsFreeListening`),
2. re-reads the current step, and
3. reopens the mic when playback finishes (`onComplete` → `_maybeStartHandsFree`).

This gives the expected behavior, repeatably: read the step aloud → mic off during playback → mic back on after.

## Testing
- `flutter analyze`: clean
- Verified on device: repeat now re-reads the step with the mic correctly muted/reopened, and works on repeated presses.
